### PR TITLE
Update EmbeddedPad.java

### DIFF
--- a/src/main/java/org/jlab/groot/graphics/EmbeddedPad.java
+++ b/src/main/java/org/jlab/groot/graphics/EmbeddedPad.java
@@ -78,7 +78,7 @@ public class EmbeddedPad {
     
     public void setAxisRange(double xmin, double xmax, double ymin, double ymax){
     	this.getAxisX().setRange(xmin, xmax);
-    	this.getAxisY().setRange(xmin, xmax);
+    	this.getAxisY().setRange(ymin, ymax);
     }
     
     public void setMargins(PadMargins margins){


### PR DESCRIPTION
This allows the y-axis ranges to be correctly set to the y-axis arguments instead of the x-axis arguments.