### PR TITLE
switch freehep url

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,28 @@
+# https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Coatjava-CI
+
+on:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ '**' ]
+  schedule:
+    # NOTE: From what I read, the email notification for cron can only go
+    #       to the last committer of this file!!!!!
+    - cron: '0 22 * * *'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: build
+      run: mvn install
+

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,6 +1,6 @@
 # https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Coatjava-CI
+name: GROOT-CI
 
 on:
   push:

--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,10 @@
             <url>https://clasweb.jlab.org/jhep/maven</url>
         </repository>
         <repository>
-            <id>freehep</id>
-            <url>https://java.freehep.org/maven2</url>
+            <!--<id>freehep</id>
+            <url>https://java.freehep.org/maven2</url>-->
+            <id>freehep-repo-public</id>
+            <url>https://srs.slac.stanford.edu/nexus/content/groups/freehep-maven2-public/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Works while currently (old?) java.freehep.org is down.  This is also what HPS does.